### PR TITLE
Add resources page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ drafted.
 
 Pull requests and comments welcome.
 
+For learning more about DLC have a look at the [resources](Resources.md) page.
+
 ## Specification Roadmap
 
 ### Works in Progress

--- a/Resources.md
+++ b/Resources.md
@@ -1,0 +1,25 @@
+# List of DLC resources
+
+This document provides a list of resources to learn about DLC.
+
+## Academic Papers
+
+* [Dryja, Thaddeus. "Discreet log contracts.", 2017](https://adiabat.github.io/dlc.pdf)
+
+## Blog Posts
+
+* [Discreet Log Contracts: invisible smart contracts on the Bitcoin blockchain](https://medium.com/@gertjaap/discreet-log-contracts-invisible-smart-contracts-on-the-bitcoin-blockchain-cc8afbdbf0db)
+* [P2P Protocol Based Crypto Asset Derivative Settled in Bitcoin on Discreet Log Contracts](https://medium.com/crypto-garage/p2p-protocol-based-crypto-asset-derivative-settled-in-bitcoin-on-discreet-log-contracts-13c823448ae8)
+* [Discreet Log Contracts Part 1: What is a Discreet Log Contract?](https://suredbits.com/discreet-log-contracts-part-1-what-is-a-discreet-log-contract/)
+* [Discreet Log Contracts Part 2: How They Work](https://suredbits.com/discreet-log-contracts-part-2-how-they-work/)
+* [Discreet Log Contracts Part 3: Why They Are Great](https://suredbits.com/discreet-log-contracts-part-3-why-they-are-great/)
+* [Discreet Log Contracts Part 4: Security and Trust Model](https://suredbits.com/discreet-log-contracts-part-4-security-and-trust-model/)
+* [skew. & Crypto Garage trade peer-to-peer Bitcoin-settled S&P500 derivatives](https://medium.com/crypto-garage/skew-crypto-garage-trade-peer-to-peer-bitcoin-settled-s-p500-derivatives-f9958db011dd)
+* [Crypto Hedging With Discreet Log Contracts](https://suredbits.com/crypto-hedging-with-discreet-log-contracts/)
+* [Discreet Log Contract Demonstration](https://suredbits.com/discreet-log-contract-demonstration/)
+
+## Talks
+
+* [Tadj Dryja at Dev++ 2017](https://www.youtube.com/watch?v=FU-rA5dkTHI)
+* [Tadj Dryja on MIT OpenCourseWare](https://www.youtube.com/watch?v=P6AX8KdXAts)
+* [Tadj Dryja at the MIT Bitcoin Expo 2020](https://livestream.com/accounts/2261474/events/9019383/videos/202643580) (starts at 49:26)


### PR DESCRIPTION
This PR adds a pages with link to resources to read up on DLC.

I just put the blog posts in chronological orders, but I can reorder if someone has a better suggestion.

Also I think at some point we should add links to implementations, but it might be better to wait until we have compatibility.