### PR TITLE
Added meeting directory and first meeting doc

### DIFF
--- a/meeting/meeting_may_6_2020.md
+++ b/meeting/meeting_may_6_2020.md
@@ -4,29 +4,47 @@
 
 * Adding intro doc (should this go into the top of readme instead?)
   * https://github.com/discreetlogcontracts/dlcspecs/issues/16
+  * Tibo has a md for this! Review needed
 * Add new blog posts (lightning dlc related) to resources page
 * Anything else for the resources page?
+  * Chris suggests we add links to reference implementations
+  * Antoine suggests a glossary like BOLT 0
 
 ## Rust DLC
 
+* Overview
+  * Yancy has a PR in for basic functionality and simple unit tests in Rust
+  * Next step is to make it look more like something that belongs in Rust BTC and will go there eventually
 * Where should code go?
   * https://github.com/discreetlogcontracts/dlcspecs/issues/17
+  * rust-bitcoin
 * Initial DLC functions
   * https://github.com/p2pderivatives/rust-dlc/pull/1
+* How do we want to do bindings to secp256k1?
+  * Fork of rust-btc's secp256k1
+    * maintained in that repo
+  * We want to have commits everyone uses off of libsecp for compatibility
 * Goals for first DLC project on rust-lightning?
   * https://github.com/rust-bitcoin/rust-lightning/issues/605
-* LN Hackathon?
+* LN Hackathon
+  * Antoine is going to post a write-up of changes that need to be implemented
+  * DLC output on LN commitment tx
+  * We need to figure out build stuff wrt libsecp256k1 beforehand if possible
+    * Actually Lloyd has us covered with a branch where we can just implement sigpoint computation
 
 ## Oracle Standards
 
 * Signature serialization standard (tagged hashes?)
   * https://github.com/discreetlogcontracts/dlcspecs/issues/21
 * Signing numbers (prices)
+  * Tibo is working on a proposal that he wants to post next week for discussion
+* Maybe look into https://blog.coinbase.com/introducing-the-coinbase-price-oracle-6d1ee22c7068
 
 ## Tweaked Public Key/Point Computation for CETs
 
 * Privacy against mempool observer
   * https://github.com/discreetlogcontracts/dlcspecs/issues/35
+  * Everyone likes the resolution of this, PR to come soon
 * Is this relevant? https://github.com/LNP-BP/LNPBPs/blob/master/lnpbp-0001.md
 
 ## Re-writing Specification (to be BOLT-like)
@@ -36,14 +54,21 @@
 * Make sure to define everything before use. Maybe a glossary?
   * https://github.com/discreetlogcontracts/dlcspecs/issues/29
 * Perhaps we want a layered design picture first, and then make spec modules follow this
+  * Nadav will open issue for this
 
 ## Interoperability and Testing
 
 * Coming up with test vectors for edge cases
   * https://github.com/discreetlogcontracts/dlcspecs/issues/30
+    * We should have separate files for unit and integration test vectors
+      * integration test vectors for things like timeouts
 * What do we need to do to become inter-operable?
   * Low R signing
   * Schnorr/BIP 340 updates
   * Fee stuff?
   * Any diffs left after that?
+    * Hard to tell but nothing we know of
 
+## DLC Coordination
+
+* Copying wasabi

--- a/meeting/meeting_may_6_2020.md
+++ b/meeting/meeting_may_6_2020.md
@@ -1,0 +1,49 @@
+# May 6th (7 PM CST)/7th (9 AM JST) Meeting
+
+## On-boarding Contributors
+
+* Adding intro doc (should this go into the top of readme instead?)
+  * https://github.com/discreetlogcontracts/dlcspecs/issues/16
+* Add new blog posts (lightning dlc related) to resources page
+* Anything else for the resources page?
+
+## Rust DLC
+
+* Where should code go?
+  * https://github.com/discreetlogcontracts/dlcspecs/issues/17
+* Initial DLC functions
+  * https://github.com/p2pderivatives/rust-dlc/pull/1
+* Goals for first DLC project on rust-lightning?
+  * https://github.com/rust-bitcoin/rust-lightning/issues/605
+* LN Hackathon?
+
+## Oracle Standards
+
+* Signature serialization standard (tagged hashes?)
+  * https://github.com/discreetlogcontracts/dlcspecs/issues/21
+* Signing numbers (prices)
+
+## Tweaked Public Key/Point Computation for CETs
+
+* Privacy against mempool observer
+  * https://github.com/discreetlogcontracts/dlcspecs/issues/35
+* Is this relevant? https://github.com/LNP-BP/LNPBPs/blob/master/lnpbp-0001.md
+
+## Re-writing Specification (to be BOLT-like)
+
+* Transactions.md
+  * https://github.com/discreetlogcontracts/dlcspecs/pull/14
+* Make sure to define everything before use. Maybe a glossary?
+  * https://github.com/discreetlogcontracts/dlcspecs/issues/29
+* Perhaps we want a layered design picture first, and then make spec modules follow this
+
+## Interoperability and Testing
+
+* Coming up with test vectors for edge cases
+  * https://github.com/discreetlogcontracts/dlcspecs/issues/30
+* What do we need to do to become inter-operable?
+  * Low R signing
+  * Schnorr/BIP 340 updates
+  * Fee stuff?
+  * Any diffs left after that?
+


### PR DESCRIPTION
as per the suggestion in #15 

I propose that any additions or modifications to the agenda be proposed here, and then after the meeting I will add notes from the meeting to the doc and anything I miss can be proposed here as well, and then after the meeting notes are in we can merge.