### PR TITLE
Use no hash oracle attestation

### DIFF
--- a/CETCompression.md
+++ b/CETCompression.md
@@ -41,9 +41,8 @@ digits where signatures were ignored.
 ## Adaptor Points with Multiple Signatures
 
 Given public key `P` and nonces `R1, ..., Rn` we can compute `n` individual signature points for
-a given event `(d1, ..., dn)` in the usual way: `si * G = Ri + H(P, Ri, di)*P`.
-To compute a composite adaptor point for all events which agree on the first `m` digits, where
-`m` is any positive number less than or equal to `n`, the sum of the corresponding signature
+a given event `(d1, ..., dn)` as follow: `si * G = Ri + di * P`.
+To compute a composite adaptor point for all events which agree on the first `m` digits, where `m` is any positive number less than or equal to `n`, the sum of the corresponding signature
 points is used: `s(1..m) * G = (s1 + s2 + ... + sm) * G = s1 * G + s2 * G + ... + sm * G`.
 
 When the oracle broadcasts its `n` signatures `s1, ..., sn`, the corresponding adaptor secret can be

--- a/Introduction.md
+++ b/Introduction.md
@@ -69,7 +69,7 @@ While the R-value is usually one of the component of a Schnorr signature, in DLC
 
 A signature point `S` is the image of a signature `s`, such that `S = s * G` where `G` is the base point of generator of an elliptic curve (or more generally a cyclic group).
 A signature point can be computed with only public information and prior to the creation of `s` if the [R-value](#r-value) `R` that will be used to create `s` is known.
-In practice, with Schnorr signatures, given `x` a secret key and `P = x * G` its associated public key, `k` a random value such that `R = k * G` and a message `m`, a signature `s` is defined as:
-`s = k + H(P || R || m) * x`
+In practice, with the currently adopted attestation scheme, given `x` a secret key and `P = x * G` its associated public key, `k` a random value such that `R = k * G` and a scalar `c` corresponding to an outcome index, a signature `s` is defined as:
+`s = k + c * x`
 A signature point `S` for `s` can be computed as:
-`S = R + H(P || R || m) * P`
+`S = R + c * P`

--- a/Messaging.md
+++ b/Messaging.md
@@ -90,7 +90,7 @@ The following convenience types are also defined:
 * `spk`: A bitcoin script public key encoded as ASM prefixed with a `u16` value indicating its length.
 * `short_contract_id`: an 8 byte value identifying a contract funding transaction on-chain (see [BOLT #7](https://github.com/lightningnetwork/lightning-rfc/blob/master/07-routing-gossip.md#definition-of-short-channel-id))
 * `bigsize`: a variable-length, unsigned integer similar to Bitcoin's CompactSize encoding, but big-endian.  Described in [BigSize](https://github.com/lightningnetwork/lightning-rfc/blob/master/01-messaging.md#appendix-a-bigsize-test-vectors).
-* `string`: a UTF-8 encoded string using [NFC for normalization](https://github.com/discreetlogcontracts/dlcspecs/issues/89), prefixed by a `bigsize` value indicating its length in bytes.
+* `string`: a UTF-8 encoded string, prefixed by a `bigsize` value indicating its length in bytes.
 
 
 ## DLC Specific Types

--- a/Oracle.md
+++ b/Oracle.md
@@ -3,31 +3,35 @@
 ## Introduction
 
 For the purpose of these specifications, an event is a digital representation of a real world fact.
-An [oracle](./Introduction.md#Oracle) is an entity that commits to publishing one or more signatures over a (number of) event outcome(s) ahead of time by releasing one or more [R-values](./Introduction.md#R-value) as well as necessary information for two parties to build a set of [CETs](./Introduction.md#Contract-Execution-Transaction-(CET)).
+An [oracle](./Introduction.md#Oracle) is an entity that commits to publishing one or more attestations over a (number of) event outcome(s) ahead of time by releasing one or more [R-values](./Introduction.md#R-value) as well as necessary information for two parties to build a set of [CETs](./Introduction.md#Contract-Execution-Transaction-(CET)).
 This necessary information is committed to in a so-called [_event descriptor_](#Event-descriptor) that will be further detailed in this document.
 
 ## Table of Contents
 
-- [Event descriptor](#event-descriptor)
-   - [Simple enumeration](#simple-enumeration)
-      - [Example: Weather tomorrow](#example-weather-tomorrow)
-   - [Digit decomposition](#digit-decomposition)
-      - [Example: BTC/USD rate](#example-btcusd-rate)
-   - [Serialization and signing of outcome values](#serialization-and-signing-of-outcome-values)
-   - [Serialization of event descriptors](#serialization-of-event-descriptors)
-      - [Version 0 `enum_event_descriptor`](#version-0-enum_event_descriptor)
-      - [Version 0 `digit_decomposition_event_descriptor`](#version-0-digit_decomposition_event_descriptor)
-   - [Oracle events](#oracle-events)
-      - [Version 0 `oracle_event`](#version-0-oracle_event)
-- [Oracle announcements](#oracle-announcements)
-  - [Version 0 `oracle_announcement`](#version-0-oracle_announcement)
-- [Oracle Attestations](#oracle-attestations)
-  - [Version 0 `oracle_attestation`](#version-0-oracle_attestation)
-- [Signing Algorithm](#signing-algorithm)
+- [Oracle specifications](#oracle-specifications)
+    - [Introduction](#introduction)
+    - [Table of Contents](#table-of-contents)
+    - [Event descriptor](#event-descriptor)
+        - [Simple enumeration](#simple-enumeration)
+            - [Example: Weather tomorrow](#example-weather-tomorrow)
+        - [Digit decomposition](#digit-decomposition)
+            - [Example: BTC/USD rate](#example-btcusd-rate)
+        - [Outcome attestation](#outcome-attestation)
+        - [Serialization of event descriptors](#serialization-of-event-descriptors)
+            - [Version 0 `enum_event_descriptor`](#version-0-enum_event_descriptor)
+            - [Version 0 `digit_decomposition_event_descriptor`](#version-0-digit_decomposition_event_descriptor)
+        - [Oracle events](#oracle-events)
+            - [Version 0 `oracle_event`](#version-0-oracle_event)
+    - [Oracle announcements](#oracle-announcements)
+            - [Version 0 `oracle_announcement`](#version-0-oracle_announcement)
+    - [Oracle Attestations](#oracle-attestations)
+            - [Version 0 `oracle_attestation`](#version-0-oracle_attestation)
+    - [Attestation Algorithm](#attestation-algorithm)
+    - [Footnotes](#footnotes)
 
 ## Event descriptor
 
-An event descriptor provides information to clients about an event for which an oracle plans on releasing a signature over its outcome.
+An event descriptor provides information to clients about an event for which an oracle plans on releasing an attestation over its outcome.
 The provided information should be sufficient for a client to create a set of adaptor signatures for some CETs that will cover all possible outcomes of the event.
 
 Here we assume that an event outcome can be represented either as a set of strings or numbers.
@@ -47,28 +51,28 @@ When a range of a numerical outcomes is large or unbounded, the oracle can repre
 
 The event descriptor should include:
 
-- base: a number representing the base in which the outcome value is decomposed and which will indicate the possible range of each digit that will be signed (e.g. 2 for binary, 10 for decimal, 16 for hex-decimal).
+- base: a number representing the base in which the outcome value is decomposed and which will indicate the possible range of each digit that will be attested (e.g. 2 for binary, 10 for decimal, 16 for hex-decimal).
 - is-signed: a boolean value indicating whether the outcomes can be negative.
 - unit: the unit of the outcome value
 - precision: the precision of the outcome representing the base exponent by which to multiply the number represented by the composition of the digits to obtain the actual outcome value.
-- number of digits: the number of digits that the oracle will sign (if `is-signed` is set to true, the number of R-values for the event will be `number of digits + 1`).
+- number of digits: the number of digits that the oracle will attest (if `is-signed` is set to true, the number of R-values for the event will be `number of digits + 1`).
 
-In the case where the number of digits that make up the outcome value exceeds the number of r-values that the oracle committed to, the oracle should sign the maximal possible value that it can attest to.
-In the case where the outcome value became negative but the oracle did not provide an extra R-value, it should sign the value 0.
+In the case where the number of digits that make up the outcome value exceeds the number of r-values that the oracle committed to, the oracle should attest the maximal possible value that it can attest.
+In the case where the outcome value became negative but the oracle did not provide an extra R-value, it should attest to the value 0.
 The minimum and maximum values that can be attested to by an oracle should thus be interpreted as `max_value or more` and `min_value or less`.
 This enables contracting party to specify payouts for the overflow and underflow cases, and avoid having to use the refund path which in most cases would be unfair.<sup id="foot1">[1](#f1)</sup>
 
-The oracle must separately provide an array of R values, one for each of the digit that will be signed, with the first value of the array being used for signing the leftmost digit. If the is-signed value is true, an additional R-value must be provided as the first element in this array, which will be used to sign the string "+" in case of an outcome with a positive value or zero value and the string "-" in case of an outcome with a negative one.
+The oracle must separately provide an array of R values, one for each of the digit that will be attested, with the first value of the array being used for attesting to the leftmost digit. If the is-signed value is true, an additional R-value must be provided as the first element in this array, which will be used to attest the string "+" in case of an outcome with a positive value or zero value and the string "-" in case of an outcome with a negative one.
 In practice this array is provided as part of the [Oracle events](#Oracle-events) structure.
 
-When the outcome is not the same order of magnitude as the maximum possible outcome, leading zeros must be signed.
+When the outcome is not the same order of magnitude as the maximum possible outcome, leading zeros must be attested.
 
 #### Example: BTC/USD rate
 
 The following example illustrates how numerical decomposition can help reduce the number of required CETs while covering a large range of possible outcomes.
 
 Alice and Bob wish to enter into a DLC at time `t` when BTC/USD ~= $10000 with a maturity time of `t+1`.
-The oracle provides 6 R-values `R0-5`, meaning that it will sign six digits `D0-5`, enabling him to attest to outcomes in the range `[000000,999999]`:
+The oracle provides 6 R-values `R0-5`, meaning that it will attest to six digits `D0-5`, enabling him to attest outcomes in the range `[000000,999999]`:
 
 ```
 base: 10
@@ -85,20 +89,18 @@ They use `R0`, `R1` and `R2` to cover the cases where BTC/USD > $10999 and <= $1
 They use `R0` and `R1` to cover the cases where BTC/USD >= $20000 and < $99999, using `D0=0` and `D1 in [2,9]`.
 Finally, they use only `D0` to cover the cases where BTC/USD >= $100000 and <= $999999, using `D0 in [1-9]`.
 
-At maturity time, if the BTC/USD rate is less than $999999, the oracle signs each of the digits representing the outcome value using the digits' corresponding R value.
-For example, if the rate at maturity time is $20000, the oracle will sign the digits `0`, `2`, `0`, `0`, `0`, `0`.
+At maturity time, if the BTC/USD rate is less than $999999, the oracle attests each of the digits representing the outcome value using the digits' corresponding R value.
+For example, if the rate at maturity time is $20000, the oracle will attest the digits `0`, `2`, `0`, `0`, `0`, `0`.
 
-If the rate is greater than $999999, the oracle signs the digits `9`, `9`, `9`, `9`, `9`, `9`.
+If the rate is greater than $999999, the oracle attests the digits `9`, `9`, `9`, `9`, `9`, `9`.
 
-### Serialization and signing of outcome values
+### Outcome attestation
 
-Every outcome value should be encoded as [a UTF-8 string with NFC normalization](./Messaging.md#Fundamental-types), before being passed to the signing algorithm.
-UTF-8 is chosen as being a widely supported and easy to implement encoding format.
+The current [attestation algorithm](#attestation-algorithm) does not produce attestations using the outcome values themselves, but instead uses the index of the outcome to attest starting with `0` for the first outcome.
 
-For numerical outcomes represented in bases greater than 10, each digit should be converted to base 10 before being encoded (note that base 10 numbers in UTF-8 take values in the 0x0030-0x0039 range).
-This helps preventing any confusion about the capitalization of letters or the introduction of non-standard characters.
+For enumerated outcome, this means the index of the outcome in the enumeration.
 
-Signing should be done using the [signing algorithm](#Signing-Algorithm) using the tag `attestation/v0`.
+In the case of digit decomposition, the value of the digit to attest should be used.
 
 ### Serialization of event descriptors
 
@@ -114,8 +116,6 @@ Event descriptors should be serialized using [TLV format](https://github.com/lig
    * [`string`:`outcome_n`]
 
 This type of event descriptor is a simple enumeration where the value `n` is the number of outcomes in the event.
-
-Note that `outcome_i` is the outcome value itself and not its hash that will be signed by the oracle.
 
 #### Version 0 `digit_decomposition_event_descriptor`
 
@@ -169,7 +169,7 @@ where `signature` is a Schnorr signature over a sha256 hash of the serialized `o
 
 ## Oracle Attestations
 
-After an event occurs, and the oracle creates signatures to attest the outcome, it needs to give them to users.
+After an event occurs, and the oracle creates signatures to attest the outcome result, it needs to give them to users.
 An oracle can use an attestation tlv to give users this information.
 
 The TLV serialization of oracle attestations is as follows.
@@ -180,33 +180,34 @@ The TLV serialization of oracle attestations is as follows.
 2. data:
     * [`string`:`event_id`]
     * [`x_point`:`oracle_public_key`]
-    * [`u16`: `nb_signatures`]
-    * [`signature`:`signature_1`]
+    * [`u16`: `nb_attestations`]
+    * [`attestation`:`attestation_1`]
     * ...
-    * [`signature`:`signature_n`]
+    * [`attestation`:`attestation_n`]
     * [`string`:`outcome_1`]
     * ...
     * [`string`:`outcome_n`]
 
-Where the signatures are ordered the same as the nonces in their original `oracle_event`.
-The outcomes should be the message signed, ordered the same as the signatures.
+Where the attestations are ordered the same as the nonces in their original `oracle_event`.
+The outcomes should be ordered the same as the attestations.
 
-## Signing Algorithm
+## Attestation Algorithm
 
-Signatures should be generated following the algorithm specified in [BIP 340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki).
-Tagged hashes should also be used as defined in the [design section of BIP 340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#Design).
+Attestations should be generated following the algorithm described in this section.
 
 The secret key (`sk`) should be the private key corresponding to the oracle's public key.
 
-The algorithm `Sign(sk, message, tag)` is defined as:
+The algorithm `Attest(sk, ci, r)` is defined as:
 
-* Let H = `tag_hash("DLC/oracle/" || tag)`
-* Let `m` = H(`message`)
-* Return `BIP340_sign(sk, m)`
+* Let `ci` the index of the outcome in the ordered list of possible outcomes that could be attested by the oracle. This list is either explicitly given by the oracle in the case of enumerated outcomes, or implicitly in the case of numerical decomposition.
+* Let `r` the pre-image of `R` announced by the oracle,
+* Return `s = r + ci * x`
+
+Details about the security of this scheme can be found [here](https://github.com/LLFourn/dlc-sec/blob/master/main.pdf).
 
 ## Footnotes
 
 <b id="f1">1</b>: More complex constructions where considered to handle these.
-For example, one considered approach was to require the oracle to sign the number of digit that make up an outcome.
+For example, one considered approach was to require the oracle to attest the number of digit that make up an outcome.
 Another one was to sign a flag indicating overflow.
 However, these make the specifications more complex, without providing any clear benefit (or without the currently specified approach having any clear downside).


### PR DESCRIPTION
Update the signature scheme to use @llfourn [proposal](https://mailmanlists.org/pipermail/dlc-dev/2020-December/000002.html)

Also removed the requirement for NFC standardization of UTF8 as it does not seem strictly necessary since we are not hashing strings anymore. If anybody can think of a reason that we should keep it please comment.