### PR TITLE
DLC Mutual Close

### DIFF
--- a/Messaging.md
+++ b/Messaging.md
@@ -29,12 +29,12 @@ All data fields are unsigned big-endian unless otherwise specified.
       - [Version 0 `negotiation_fields`](#version-0-negotiation_fields)
       - [Version 1 `negotiation_fields`](#version-1-negotiation_fields)
       - [Version 2 `negotiation_fields`](#version-2-negotiation_fields)
-   - [The `funding_input` Type](#the-funding_input-type)
-      - [Version 0 `funding_input`](#version-0-funding_input)
+   - [The `input` Type](#the-input-type)
+      - [Version 0 `input`](#version-0-input)
    - [The `cet_adaptor_signatures` Type](#the-cet_adaptor_signatures-type)
       - [Version 0 `cet_adaptor_signatures`](#version-0-cet_adaptor_signatures)
-   - [The `funding_signatures` Type](#the-funding_signatures-type)
-      - [Version 0 `funding_signatures`](#version-0-funding_signatures)
+   - [The `input_signatures` Type](#the-input_signatures-type)
+      - [Version 0 `input_signatures`](#version-0-input_signatures)
    - [The `event_descriptor` Type](#the-event_descriptor-type)
       - [Version 0 `enum_event_descriptor`](#version-0-enum_event_descriptor)
       - [Version 0 `digit_decomposition_event_descriptor`](#version-0-digit_decomposition_event_descriptor)
@@ -258,13 +258,13 @@ This type is used within `dlc_accept` messages that respond to `dlc_offer`s cont
 The `num_disjoint_events` here must be equal to the `num_disjoint_events` in that `contract_info_v1` and
 all of the `negotiation_fields` nested here must be version 0 or 1.
 
-### The `funding_input` Type
+### The `input` Type
 
-This type contains information about a specific input to be used in a funding transaction, as well as its corresponding on-chain UTXO.
+This type contains information about a specific input to be used in a funding or closing transaction, as well as its corresponding on-chain UTXO.
 
-#### Version 0 `funding_input`
+#### Version 0 `input`
 
-1. type: 42772 (`funding_input_v0`)
+1. type: 42772 (`input_v0`)
 2. data:
    * [`u64`:`input_serial_id`]
    * [`u16`:`prevtx_len`]
@@ -281,7 +281,7 @@ Inputs in the funding transaction will be sorted by `input_serial_id`.
 The transaction is used to validate this spent output's value and to validate that it is a SegWit output.
 
 `max_witness_len` is the total serialized length of the witness data that will be supplied
-(e.g. sizeof(varint) + sizeof(witness) for each) in `funding_signatures`.
+(e.g. sizeof(varint) + sizeof(witness) for each) in `input_signatures`.
 
 `redeemscript` the witness script public key to be revealed for P2SH spending.
 Only applicable for P2SH-wrapped inputs.
@@ -307,13 +307,13 @@ This type contains CET signatures and any necessary information linking the sign
 
 This type should be used with [`contract_info_v0`](#version-0-contract_info) where each indexed signature in the data corresponds to the outcome of the same index.
 
-### The `funding_signatures` Type
+### The `input_signatures` Type
 
-This type contains signatures of the funding transaction and any necessary information linking the signatures to their inputs.
+This type contains signatures of the funding or closing transaction and any necessary information linking the signatures to their inputs.
 
-#### Version 0 `funding_signatures`
+#### Version 0 `input_signatures`
 
-1. type: 42776 (`funding_signatures_v0`)
+1. type: 42776 (`input_signatures_v0`)
 2. data:
    * [`u16`:`num_witnesses`]
    * [`u16`:`num_witness_elems_1`]
@@ -329,7 +329,7 @@ This type contains signatures of the funding transaction and any necessary infor
 `witness` is the data for a witness element in a witness stack. An empty `witness_stack` is an error,
 as every input must be Segwit. Witness elements should *not* include their length as part of the witness data.
 
-Witnesses should be sorted by the `input_serial_id` sent in `funding_input` defining these inputs.
+Witnesses should be sorted by the `input_serial_id` sent in funding `input` defining these inputs.
 
 ### The `event_descriptor` Type
 

--- a/Protocol.md
+++ b/Protocol.md
@@ -279,9 +279,9 @@ The recipient:
 
   These script pub key forms include only standard forms accepted by the wider set of deployed Bitcoin clients in the network, which increase the chances of successful propagation to miners.
 
-## Second Layer Interaction
+## Optional features
 
-Second Layer Interaction consist of second layer "features" which parties can opt-in to using. These messages are not needed to facilitate construction of a DLCs.
+Optional features consist of "features" which parties can opt-in to using. These messages are not needed to facilitate construction of a DLCs.
 
 ### The `close_dlc` Message
 
@@ -301,24 +301,24 @@ to broadcast a mutual closing transaction.
 
 `payout_spk` and `payout_serial_id` from `offer_dlc` as well as `payout_spk` and `payout_serial_id` from `accept_dlc` should be used for constructing the close transaction
 
-`fund_input_serial_id` is a randomly chosen number which uniquely identifies the funding input of the initiating party.
+`fund_input_serial_id` is a randomly chosen number which uniquely identifies the funding output to be spent.
 Inputs in the closing transaction will be sorted by `fund_input_serial_id` and `input_serial_id` in `funding_inputs`.
 
-`funding_inputs` are extra inputs to mutual close to avoid free option, and in the future revocation mechanism will be introduced
+`funding_inputs` are extra inputs to mutual close to enable the sending party to nullify the transaction by double spending the inputs.
 
 #### Requirements
 
 The sender MUST:
 
-  - set `contract_id` by exclusive-OR of the `funding_txid`, the `funding_output_index` and the `temporary_contract_id` from the `offer_dlc` and `accept_dlc` messages.
-  - set `close_signature` to the valid signature, using its `funding_pubkey` for the close transaction, as defined in the [transaction specification](Transactions.md#close-transaction).
+  - set `contract_id` from the `sign_dlc` message.
+  - set `close_signature` to a valid signature, using its `funding_pubkey` for the close transaction, as defined in the [transaction specification](Transactions.md#close-transaction).
 
 The recipient:
 
   - if any input in `funding_inputs` is not a BIP141 (Segregated Witness) input.
-    - MUST reject the contract.
+    - MUST ignore the message.
   - if the `close_signature` is incorrect:
-    - MUST reject the contract.
+    - MUST ignore the message.
   - MUST NOT broadcast the closing transaction before receipt of a valid `close_dlc`.
   - on receipt of a valid `close_dlc`:
     - SHOULD broadcast the closing transaction.

--- a/Protocol.md
+++ b/Protocol.md
@@ -298,6 +298,7 @@ to broadcast a mutual closing transaction.
    * [`u16`:`num_extra_inputs`]
    * [`num_extra_inputs*extra_input`:`extra_inputs`]
    * [`extra_signatures`:`extra_signatures`]
+   * [`u32`:`close_locktime`]
 
 
 `payout_spk` and `payout_serial_id` from `offer_dlc` as well as `payout_spk` and `payout_serial_id` from `accept_dlc` should be used for constructing the close transaction
@@ -307,6 +308,8 @@ Inputs in the closing transaction will be sorted by `fund_input_serial_id` and `
 
 `extra_inputs` are extra inputs to mutual close to enable the sending party to nullify the transaction by double spending the inputs.
 
+`close_locktime` is the nLockTime to be put in close messages.
+
 #### Requirements
 
 The sender MUST:
@@ -314,6 +317,8 @@ The sender MUST:
   - set `contract_id` from the `sign_dlc` message.
   - set `close_signature` to a valid signature, using the private key associated with its `funding_pubkey` for the close transaction, as defined in the [transaction specification](Transactions.md#close-transaction).
   - set `extra_signatures` to contain valid witnesses for every funding input specified by `extra_inputs` and in the same order.
+  - set `close_locktime` to be a UNIX timestamp, or a block height as distinguished [here](https://en.bitcoin.it/wiki/NLockTime).
+  - set `close_locktime` to be less than or equal to current UNIX timestamp or block.
 
 The recipient:
 

--- a/Protocol.md
+++ b/Protocol.md
@@ -316,10 +316,9 @@ The sender MUST:
 The recipient:
 
   - if any input in `funding_inputs` is not a BIP141 (Segregated Witness) input.
-    - MUST ignore the message.
+    - MAY ignore the message.
   - if the `close_signature` is incorrect:
     - MUST ignore the message.
-  - MUST NOT broadcast the closing transaction before receipt of a valid `close_dlc`.
   - on receipt of a valid `close_dlc`:
     - SHOULD broadcast the closing transaction.
 

--- a/Protocol.md
+++ b/Protocol.md
@@ -312,7 +312,7 @@ Inputs in the closing transaction will be sorted by `fund_input_serial_id` and `
 The sender MUST:
 
   - set `contract_id` from the `sign_dlc` message.
-  - set `close_signature` to a valid signature, using its `funding_pubkey` for the close transaction, as defined in the [transaction specification](Transactions.md#close-transaction).
+  - set `close_signature` to a valid signature, using the private key associated with its `funding_pubkey` for the close transaction, as defined in the [transaction specification](Transactions.md#close-transaction).
   - set `funding_signatures` to contain valid witnesses for every funding input specified by `funding_inputs` and in the same order.
 
 The recipient:

--- a/Protocol.md
+++ b/Protocol.md
@@ -9,6 +9,8 @@
           * [The `accept_dlc` Message](#the-accept_dlc-message)
           * [The `sign_dlc` Message](#the-sign_dlc-message)
           * [Script Pubkey Standardness Definition](#script-pubkey-standardness-definition)
+      * [Optional Features](#optional-features)
+          * [The `close_dlc` Message](#the-close_dlc-message)
 * [Authors](#authors)
 
 # Contract

--- a/Protocol.md
+++ b/Protocol.md
@@ -295,17 +295,17 @@ to broadcast a mutual closing transaction.
    * [`u64`:`offerPayoutSatoshis`]
    * [`u64`:`acceptPayoutSatoshis`]
    * [`u64`:`fund_input_serial_id`]
-   * [`u16`:`num_funding_inputs`]
-   * [`num_funding_inputs*funding_input`:`funding_inputs`]
-   * [`funding_signatures`:`funding_signatures`]
+   * [`u16`:`num_extra_inputs`]
+   * [`num_extra_inputs*extra_input`:`extra_inputs`]
+   * [`extra_signatures`:`extra_signatures`]
 
 
 `payout_spk` and `payout_serial_id` from `offer_dlc` as well as `payout_spk` and `payout_serial_id` from `accept_dlc` should be used for constructing the close transaction
 
 `fund_input_serial_id` is a randomly chosen number which uniquely identifies the funding output to be spent.
-Inputs in the closing transaction will be sorted by `fund_input_serial_id` and `input_serial_id` in `funding_inputs`.
+Inputs in the closing transaction will be sorted by `fund_input_serial_id` and `input_serial_id` in `extra_inputs`.
 
-`funding_inputs` are extra inputs to mutual close to enable the sending party to nullify the transaction by double spending the inputs.
+`extra_inputs` are extra inputs to mutual close to enable the sending party to nullify the transaction by double spending the inputs.
 
 #### Requirements
 
@@ -313,13 +313,13 @@ The sender MUST:
 
   - set `contract_id` from the `sign_dlc` message.
   - set `close_signature` to a valid signature, using the private key associated with its `funding_pubkey` for the close transaction, as defined in the [transaction specification](Transactions.md#close-transaction).
-  - set `funding_signatures` to contain valid witnesses for every funding input specified by `funding_inputs` and in the same order.
+  - set `extra_signatures` to contain valid witnesses for every funding input specified by `extra_inputs` and in the same order.
 
 The recipient:
 
-  - if any input in `funding_inputs` is not a BIP141 (Segregated Witness) input.
+  - if any input in `extra_inputs` is not a BIP141 (Segregated Witness) input.
     - MAY ignore the message.
-  - if any `signature` or `witness` in `funding_signatures` is incorrect:
+  - if any `signature` or `witness` in `extra_signatures` is incorrect:
     - MUST ignore the message.
   - if the `close_signature` is incorrect:
     - MUST ignore the message.

--- a/Protocol.md
+++ b/Protocol.md
@@ -326,6 +326,10 @@ The recipient:
 
   - if any input in `extra_inputs` is not a BIP141 (Segregated Witness) input.
     - MAY ignore the message.
+  - if `offer_payout_satoshis` is greater than zero and below the dust limit
+    - MUST ignore the message
+  - if `accept_payout_satoshis` is greater than zero and below the dust limit
+    - MUST ignore the message
   - if any `signature` or `witness` in `extra_signatures` is incorrect:
     - MUST ignore the message.
   - if the `close_signature` is incorrect:

--- a/Protocol.md
+++ b/Protocol.md
@@ -75,8 +75,8 @@ the funding transaction and CETs.
    * [`spk`:`payout_spk`]
    * [`u64`:`payout_serial_id`]
    * [`u64`:`offer_collateral_satoshis`]
-   * [`u16`:`num_funding_inputs`]
-   * [`num_funding_inputs*funding_input`:`funding_inputs`]
+   * [`u16`:`num_inputs`]
+   * [`num_inputs*input`:`inputs`]
    * [`spk`:`change_spk`]
    * [`u64`:`change_serial_id`]
    * [`u64`:`fund_output_serial_id`]
@@ -99,8 +99,8 @@ the funding transaction output. `payout_spk` specifies the script
 pubkey that CETs and the refund transaction should use in the sender's output.
 
 `offer_collateral_satoshis` is the amount the sender is putting into the
-contract. `num_funding_inputs` is the number of funding inputs contributed by
-the sender and `funding_inputs` contains outputs, outpoints, and expected weights
+contract. `num_inputs` is the number of funding inputs contributed by
+the sender and `inputs` contains outputs, outpoints, and expected weights
 of the sender's funding inputs. `change_spk` specifies the script pubkey that funding
 change should be sent to.
 
@@ -162,10 +162,10 @@ The receiving node MUST reject the contract if:
   - `payout_spk` or `change_spk` are not a [standard script pubkey](#script-pubkey-standardness-definition).
   - it considers `feerate_per_vb` too small for timely processing or unreasonably large.
   - `funding_pubkey` is not a valid secp256k1 pubkey in compressed format.
-  - `funding_inputs` do not contribute at least `total_collateral_satoshis` plus full [fee payment](Transactions.md#fee-payment).
+  - `inputs` do not contribute at least `total_collateral_satoshis` plus full [fee payment](Transactions.md#fee-payment).
   - Any `input_serial_id` is duplicated
   - The `fund_output_serial_id` and `change_serial_id` are not set to different value
-  - Any input in `funding_inputs` is not a BIP141 (Segregated Witness) input.
+  - Any input in `inputs` is not a BIP141 (Segregated Witness) input.
 
 ### The `accept_dlc` Message
 
@@ -181,8 +181,8 @@ and closing transactions.
    * [`point`:`funding_pubkey`]
    * [`spk`:`payout_spk`]
    * [`u64`:`payout_serial_id`]
-   * [`u16`:`num_funding_inputs`]
-   * [`num_funding_inputs*funding_input`:`funding_inputs`]
+   * [`u16`:`num_inputs`]
+   * [`num_inputs*input`:`inputs`]
    * [`spk`:`change_spk`]
    * [`u64`:`change_serial_id`]
    * [`cet_adaptor_signatures`:`cet_adaptor_signatures`]
@@ -216,11 +216,11 @@ The receiver:
     - MAY reject the contract.
   - if `payout_spk` or `change_spk` are not a [standard script pubkey](#script-pubkey-standardness-definition)
     - MUST reject the contract.
-  - if any input in `funding_inputs` is not a BIP141 (Segregated Witness) input.
+  - if any input in `inputs` is not a BIP141 (Segregated Witness) input.
     - MUST reject the contract.
   - if `cet_adaptor_signatures` or `refund_signature` fail validation:
     - MUST reject the contract.
-  - if `funding_inputs` do not contribute at least `accept_collateral_satoshis` plus [fee payment](Transactions.md#fee-payment)
+  - if `inputs` do not contribute at least `accept_collateral_satoshis` plus [fee payment](Transactions.md#fee-payment)
     - MUST reject the contract.
   - if any `input_serial_id` is duplicated
     - MUST reject the contract.
@@ -246,7 +246,7 @@ This message introduces the [`contract_id`](#definition-of-contract_id) to ident
    * [`contract_id`:`contract_id`]
    * [`cet_adaptor_signatures`:`cet_adaptor_signatures`]
    * [`signature`:`refund_signature`]
-   * [`funding_signatures`:`funding_signatures`]
+   * [`input_signatures`:`input_signatures`]
 
 #### Requirements
 
@@ -256,7 +256,7 @@ The sender MUST:
   - set `cet_adaptor_signatures` to valid adaptor signatures, using its `funding_pubkey` for each CET, as defined in the [transaction specification](Transactions.md#contract-execution-transaction) and using signature public keys computed using the `offer_dlc`'s `contract_info` and `oracle_info` as adaptor points.
   - include an adaptor signature in `cet_adaptor_signatures` for every event specified in the `offer_dlc`'s `contract_info`.
   - set `refund_signature` to the valid signature, using its `funding_pubkey` for the refund transaction, as defined in the [transaction specification](Transactions.md#refund-transaction).
-  - set `funding_signatures` to contain valid witnesses for every funding input specified in the `offer_dlc` message and in the same order.
+  - set `input_signatures` to contain valid witnesses for every funding input specified in the `offer_dlc` message and in the same order.
 
 The recipient:
 
@@ -294,12 +294,12 @@ to broadcast a mutual closing transaction.
 2. data:
    * [`32*byte`:`contract_id`]
    * [`signature`:`close_signature`]
-   * [`u64`:`offerPayoutSatoshis`]
-   * [`u64`:`acceptPayoutSatoshis`]
+   * [`u64`:`offer_payout_satoshis`]
+   * [`u64`:`accept_payout_satoshis`]
    * [`u64`:`fund_input_serial_id`]
    * [`u16`:`num_extra_inputs`]
-   * [`num_extra_inputs*extra_input`:`extra_inputs`]
-   * [`extra_signatures`:`extra_signatures`]
+   * [`num_extra_inputs*input`:`extra_inputs`]
+   * [`input_signatures`:`input_signatures`]
    * [`u32`:`close_locktime`]
 
 

--- a/Protocol.md
+++ b/Protocol.md
@@ -297,6 +297,7 @@ to broadcast a mutual closing transaction.
    * [`u64`:`fund_input_serial_id`]
    * [`u16`:`num_funding_inputs`]
    * [`num_funding_inputs*funding_input`:`funding_inputs`]
+   * [`funding_signatures`:`funding_signatures`]
 
 
 `payout_spk` and `payout_serial_id` from `offer_dlc` as well as `payout_spk` and `payout_serial_id` from `accept_dlc` should be used for constructing the close transaction
@@ -312,11 +313,14 @@ The sender MUST:
 
   - set `contract_id` from the `sign_dlc` message.
   - set `close_signature` to a valid signature, using its `funding_pubkey` for the close transaction, as defined in the [transaction specification](Transactions.md#close-transaction).
+  - set `funding_signatures` to contain valid witnesses for every funding input specified by `funding_inputs` and in the same order.
 
 The recipient:
 
   - if any input in `funding_inputs` is not a BIP141 (Segregated Witness) input.
     - MAY ignore the message.
+  - if any `signature` or `witness` in `funding_signatures` is incorrect:
+    - MUST ignore the message.
   - if the `close_signature` is incorrect:
     - MUST ignore the message.
   - on receipt of a valid `close_dlc`:

--- a/Transactions.md
+++ b/Transactions.md
@@ -34,7 +34,7 @@ The funding inputs and change output script public keys are negotiated in the of
 
 ## Funding Transaction Input and Output Ordering
 
-The inputs are sorted by each `funding_input`'s `input_serial_id` in ascending order.
+The inputs are sorted by each funding `input`'s `input_serial_id` in ascending order.
 The outputs are sorted in ascending order based on their respective `change_serial_id` or `fund_output_serial_id`.
 
 ## Funding Inputs

--- a/Transactions.md
+++ b/Transactions.md
@@ -101,7 +101,7 @@ The refund transaction is exactly the same as a [Contract Execution Transaction]
 
 # Close Transaction
 
-The close transaction is exactly the same as a [Contract Execution Transaction](#contract-execution-transaction) except that its locktime is `0` and it has additional funding input(s) that are used to avoid the free option problem.
+The close transaction is similar to [Contract Execution Transaction](#contract-execution-transaction). The main differences are that locktime is `0` and it has additional funding input(s) that are used to avoid the free option problem.
 
 # Fees
 

--- a/Transactions.md
+++ b/Transactions.md
@@ -99,6 +99,10 @@ This output sends funds won by the accepter corresponding to this CET's outcome 
 
 The refund transaction is exactly the same as a [Contract Execution Transaction](#contract-execution-transaction) except that its locktime is `refund_locktime` (as negotiated in the offer message) instead of `cet_locktime` and the output values for the offerer and the accepter are their respective total collateral values from their offer/accept messages.
 
+# Close Transaction
+
+The close transaction is exactly the same as a [Contract Execution Transaction](#contract-execution-transaction) except that its locktime is `0` and it has additional funding input(s) that are used to avoid the free option problem.
+
 # Fees
 
 ### Fee Calculation

--- a/test/dlc_message_test.json
+++ b/test/dlc_message_test.json
@@ -25,7 +25,7 @@
     "rValue" : "9e7eaeb2624a93bba2f132da687862f73038c2e5769c812c7b0ba4b654a3e856"
   }
 }, {
-  "tpeName" : "funding_input_v0",
+  "tpeName" : "input_v0",
   "input" : "fda71437002902000000000100c2eb0b00000000160014781c327deed64538720dc4c857a0712111020c740000000000000000ffffffff006b0000",
   "fields" : {
     "tpe" : "fda714",


### PR DESCRIPTION
This PR adds new `close_dlc` as per the discussion regarding https://github.com/discreetlogcontracts/dlcspecs/issues/161 which enables a way to request to close a DLC before cet_locktime with mutual consent