### PR TITLE
Remove bitcoin-s github branch link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ For more information on works in progress and TODOs, see our [pull requests](htt
 The team at Suredbits is working on a implementation of discreet log contracts in bitcoin-s. 
 
 1. [Documentation](https://bitcoin-s.org/docs/next/wallet/dlc)
-2. [Github branch](https://github.com/bitcoin-s/bitcoin-s/tree/adaptor-dlc/dlc/src/main/scala/org/bitcoins/dlc)
-3. [Interactive DLC Demo](https://scastie.scala-lang.org/nkohen/OVWMOXwPRryREhVNw7pjLw/11)
+2. [Interactive DLC Demo](https://scastie.scala-lang.org/nkohen/OVWMOXwPRryREhVNw7pjLw/11)
 
 ### [cfd-dlc](https://github.com/p2pderivatives/cfd-dlc)
 


### PR DESCRIPTION
DLCs are now merged into master in bitcoin-s, no need to link to a specific branch