### PR TITLE
Add validity requirement to contract descriptor

### DIFF
--- a/Messaging.md
+++ b/Messaging.md
@@ -139,6 +139,9 @@ This type contains information about a contract's outcomes and their correspondi
 To save space, only the offerer's payouts are included in this message as the accepter's can be derived using
 `accept_payout = total_collateral - offer_payout`.
 
+**Validity requirement**
+For a contract descriptor to be valid, it is necessary that *a single* payout is defined for any possible outcome that can be attested by the oracle(s).
+
 #### Version 0 `contract_descriptor`
 
 1. type: 42768 (`contract_descriptor_v0`)

--- a/Protocol.md
+++ b/Protocol.md
@@ -130,6 +130,7 @@ The sending node MUST:
   - set `cet_locktime` to be less than `refund_locktime`.
   - use a unique `input_serial_id` for each input
   - set `change_serial_id` and `fund_output_serial_id` to different values
+  - use valid [contract descriptor(s)](./Messaging.md#The-contract_descriptor-Type) within `contract_info`.
 
 The sending node SHOULD:
 
@@ -164,6 +165,7 @@ The receiving node MUST reject the contract if:
   - Any `input_serial_id` is duplicated
   - The `fund_output_serial_id` and `change_serial_id` are not set to different value
   - Any input in `funding_inputs` is not a BIP141 (Segregated Witness) input.
+  - invalid [contract descriptor(s)](./Messaging.md#The-contract_descriptor-Type) are used within `contract_info`.
 
 ### The `accept_dlc` Message
 


### PR DESCRIPTION
Specify that a contract descriptor needs to cover all possible outcomes that can be attested by the oracle(s).