### PR TITLE
Correct Typo in Signature Point calculation

### DIFF
--- a/Introduction.md
+++ b/Introduction.md
@@ -76,6 +76,6 @@ While the R-value is usually one of the component of a Schnorr signature, in DLC
 A signature point `S` is the image of a signature `s`, such that `S = s * G` where `G` is the base point of generator of an elliptic curve (or more generally a cyclic group).
 A signature point can be computed with only public information and prior to the creation of `s` if the [R-value](#r-value) `R` that will be used to create `s` is known.
 In practice, with Schnorr signatures, given `x` a secret key and `P = x * G` its associated public key, `k` a random value such that `R = k * G` and a message `m`, a signature `s` is defined as:
-`s = k + H(P || R || m) * x`
+`s = k + H(R || P || m) * x`
 A signature point `S` for `s` can be computed as:
-`S = R + H(P || R || m) * P`
+`S = R + H(R || P || m) * P`


### PR DESCRIPTION
in BIP340,  the signature Point is calculated like so: `s⋅G = R + hash(R || P || m)⋅P`. Unless the order of inputs to the hash function is changed here from BIP 340, this is a typo.

see: https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#design