### PR TITLE
Specify not to round above total collateral

### DIFF
--- a/NumericOutcome.md
+++ b/NumericOutcome.md
@@ -58,7 +58,7 @@ of both party's rounding moduli.
 
 If `R` is the rounding modulus to be used for a given `event_outcome` and the result of function evaluation for that `event_outcome` is `value`,
 then the amount to be used in the CET output for this party will be the closer of `value - (value % R)` or `value - (value % R) + R`, rounding
-up in the case of a tie.
+up in the case of a tie, making sure not to round over the total collateral of the contract.
 
 #### Reference Implementations
 


### PR DESCRIPTION
@luckysori found an issue in rust dlc where the payout was being rounded above the total collateral of the contract. This PR updates the spec to specify that one should make sure to always round below the total collateral. I don't know if bitcoin-s has this issue or not.