### PR TITLE
Changes to the standard scripts

### DIFF
--- a/Protocol.md
+++ b/Protocol.md
@@ -303,7 +303,7 @@ OP_HASH160 <20-bytes> OP_EQUAL
 # Pay-to-witness-pubkey-hash (P2WPKH), version 0
 OP_0 <20-bytes>
 
-# Pay-to-witness-pubkey-hash (P2WSH), version 0
+# Pay-to-witness-script-hash (P2WSH), version 0
 OP_0 <32-bytes>
 
 # Witness program versions 1 through 16, followed by a single push of 2 to 40 bytes

--- a/Protocol.md
+++ b/Protocol.md
@@ -293,14 +293,27 @@ The recipient:
 
  For a script pub key to be valid it must be in one of the following forms:
 
-    1. `OP_DUP` `OP_HASH160` `20` 20-bytes `OP_EQUALVERIFY` `OP_CHECKSIG` (pay to pubkey hash), OR
-    2. `OP_HASH160` `20` 20-bytes `OP_EQUAL` (pay to script hash), OR
-    3. `OP_0` `20` 20-bytes (version 0 pay to witness pubkey hash), OR
-    4. `OP_0` `32` 32-bytes (version 0 pay to witness script hash), OR
-    5. `OP_1` through `OP_16` inclusive, followed by a single push of 2 to 40 bytes
-       (witness program versions 1 through 16)
+```bash
+# Pay-to-pubkey-hash (P2PKH)
+OP_DUP OP_HASH160 <20-bytes> OP_EQUALVERIFY OP_CHECKSIG
 
+# Pay-to-script-hash (P2SH)
+OP_HASH160 <20-bytes> OP_EQUAL
+
+# Pay-to-witness-pubkey-hash (P2WPKH), version 0
+OP_0 <20-bytes>
+
+# Pay-to-witness-pubkey-hash (P2WSH), version 0
+OP_0 <32-bytes>
+
+# Witness program versions 1 through 16, followed by a single push of 2 to 40 bytes
+OP_1 <2-to-40-bytes>
+OP_2 <2-to-40-bytes>
+...
+OP_16 <2-to-40-bytes>
+```
   These script pub key forms include only standard forms accepted by the wider set of deployed Bitcoin clients in the network, which increase the chances of successful propagation to miners.
+  More information about the Script language can be found here: https://en.bitcoin.it/wiki/Script .
 
 # Authors
 

--- a/Transactions.md
+++ b/Transactions.md
@@ -46,7 +46,7 @@ All funding inputs must be Segwit or nested P2SH(Segwit) in order to protect aga
 * The funding output script is a P2WSH to:
 
 ```
-2 <pubkey1> <pubkey2> 2 OP_CHECKMULTISIG
+OP_2 <pubkey1> <pubkey2> OP_2 OP_CHECKMULTISIG
 ```
 
 * Where `pubkey1` is the lexicographically lesser of `offer_funding_pubkey` and `accept_funding_pubkey`, and where `pubkey2` is the lexicographically greater of the two.


### PR DESCRIPTION
The description in the specs about the acceptable standard scripts is confusing (or wrong, depending on how it's read).
For example, the typical P2PKH script has this form:
OP_DUP OP_HASH160 <20-bytes> OP_EQUALVERIFY OP_CHECKSIG 

not this one (as written in the current specs - notice the number '20' in the script)
OP_DUP OP_HASH160 **20** <20-bytes> OP_EQUALVERIFY OP_CHECKSIG 

I might be wrong, but I couldn't find a reference where such '20' or '32' is pushed before the actual hashes. Maybe it was intended for clarity? 
In any case, I believe my proposal here is slightly more clear. 
Reference: https://en.bitcoin.it/wiki/Script#Standard_Transaction_to_Bitcoin_address_(pay-to-pubkey-hash)