### PR TITLE
Description  to ECDSA adaptor signature and DLEQ proof types

### DIFF
--- a/ECDSA-adaptor.md
+++ b/ECDSA-adaptor.md
@@ -67,9 +67,9 @@ The challenge hash `H` below is defined as `H(x) = scalar(SHA256(tag || x))`.
 
 ### Proving
 
-The `DLEQ_prove(x, (X, Y, Z))` algorithm takes the following inputs:
+The `DLEQ_prove(k, (X, Y, Z))` algorithm takes the following inputs:
 
-- `x`: A **non-zero** scalar representing the witness for the proof.
+- `k`: A **non-zero** scalar representing the witness for the proof.
 - `(X, Y, Z)`: Three **non-zero** secp256k1 points which define the statement to be verified.
 
 and is defined as:
@@ -78,7 +78,7 @@ and is defined as:
 - Set `A_G` to `a * G`
 - Set `A_Y` to `a * Y`
 - Set `b` to  `H(X || Y || Z || A_G || A_Y)`
-- Set `c` to `a + b * x`
+- Set `c` to `a + b * k`
 - Set `proof` to `b || c`
 - Return `proof`
 

--- a/Messaging.md
+++ b/Messaging.md
@@ -120,14 +120,15 @@ integers can be omitted:
 
 The following convenience types are also defined:
 
-* `chain_hash`: a 32-byte chain identifier (see [BOLT #0](https://github.com/lightningnetwork/lightning-rfc/blob/master/00-introduction.md#chain_hash))
-* `contract_id`: a 32-byte contract_id (see [Protocol Specification](Protocol.md))
-* `sha256`: a 32-byte SHA2-256 hash
-* `signature`: a 64-byte bitcoin Elliptic Curve signature
-* `ecdsa_adaptor_signature`: a 65-byte ECDSA adaptor signature (TODO: link to doc once [#50](https://github.com/discreetlogcontracts/dlcspecs/issues/50) is done)
-* `dleq_proof`: a 97-byte zero-knowledge proof of discrete log equality (TODO: link to doc once [#50](https://github.com/discreetlogcontracts/dlcspecs/issues/50) is done)
-* `x_point`: a 32-byte x-only public key with implicit y-coordinate being even as in [BIP 340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#design)
-* `point`: a 33-byte Elliptic Curve point (compressed encoding as per [SEC 1 standard](http://www.secg.org/sec1-v2.pdf#subsubsection.2.3.3))
+* `chain_hash`: a 32-byte chain identifier (see [BOLT #0](https://github.com/lightningnetwork/lightning-rfc/blob/master/00-introduction.md#chain_hash)).
+* `contract_id`: a 32-byte contract_id (see [Protocol Specification](Protocol.md)).
+* `sha256`: a 32-byte SHA2-256 hash.
+* `signature`: a 64-byte bitcoin Elliptic Curve signature.
+* `ecdsa_adaptor_signature`: a 65-byte ECDSA adaptor signature (TODO: link to doc once [#50](https://github.com/discreetlogcontracts/dlcspecs/issues/50) is done).
+* `dleq_proof`: a 97-byte zero-knowledge proof of discrete log equality (TODO: link to doc once [#50](https://github.com/discreetlogcontracts/dlcspecs/issues/50) is done).
+* `x_point`: a 32-byte x-only public key with implicit y-coordinate being even as in [BIP 340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#design).
+* `point`: a 33-byte Elliptic Curve point (compressed encoding as per [SEC 1 standard](http://www.secg.org/sec1-v2.pdf#subsubsection.2.3.3)).
+* `scalar`: a 32-byte big-endian encoded integer as per [this description](https://github.com/discreetlogcontracts/dlcspecs/blob/master/ECDSA-adaptor.md#notation-and-conventions).
 * `spk`: A bitcoin script public key encoded as ASM prefixed with a `u16` value indicating its length.
 * `short_contract_id`: an 8 byte value identifying a contract funding transaction on-chain (see [BOLT #7](https://github.com/lightningnetwork/lightning-rfc/blob/master/07-routing-gossip.md#definition-of-short-channel-id))
 * `bigsize`: a variable-length, unsigned integer similar to Bitcoin's CompactSize encoding, but big-endian.  Described in [BigSize](https://github.com/lightningnetwork/lightning-rfc/blob/master/01-messaging.md#appendix-a-bigsize-test-vectors).
@@ -334,6 +335,41 @@ This type contains CET signatures and any necessary information linking the sign
    * ...
    * [`ecdsa_adaptor_signature`:`signature_n`]
    * [`dleq_proof`:`dleq_prf_n`]
+
+### The `ecdsa_adaptor_signature` Type
+This type contains an ECDSA adaptor signature, represented as a 65-byte stream that contains the following:  
+
+`R`: a 33-byte compressed elliptic-curve adaptor point as described in [Fundamental Types](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Messaging.md#fundamental-types).
+- The point `R` is calculated by multiplying the random value `r` by `G`, as described [here](https://note.com/crypto_garage/n/na1ef06177b27).
+
+`s'`: a 32-byte encrypted signature scalar. This is calculated as ```s' = r^-1(H(m) + rTp)``` as explained [here](https://note.com/crypto_garage/n/na1ef06177b27).  
+- Note that `H(m)` is the 32-byte transaction id `txid` (not to confuse with the `m_o` in the Tweak points, where `m_o` is the outcome value published by the oracle, such as `heads` or `tails`, etc.)
+- To calculate the adaptor signature scalar for numeric decomposition, one needs to calculate one tweak point `T_i` per digit and then obtain `T = T_0 + T_1 + ... + T_(i-1)` as described [here](https://medium.com/crypto-garage/optimizing-numeric-outcome-dlc-creation-6d6091ac0e47).
+
+#### `ecdsa_adaptor_signature`
+1. data: 
+  * [`point`:`R`]
+  * [`scalar`:`s'`]
+
+### The `dleq_proof` Type
+This type contains a 97-byte zero-knowledge proof of discrete log equality. The values here presented are built as described in [this article by Ichiro Kuwahara](https://medium.com/crypto-garage/adaptor-signature-in-discreet-log-contracts-on-ecdsa-c8c04197e11f).  
+
+`R'`: a 33-byte compressed elliptic-curve adaptor point as described in [Fundamental Types](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Messaging.md#fundamental-types).  
+- The point `R'` is derived as `R' = rT`, where `T` is the tweak point (or adaptor point).
+- The tweak point `T` is calculated as `T = R_o + H(R_o|P_o|m_o)`, where:
+  - `R_o` is the nonce point published by the oracle, encoded as `x_point` (see  [Fundamental Types](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Messaging.md#fundamental-types)).
+  - `P_o` is the oracle public key, encoded as `x_point` (see  [Fundamental Types](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Messaging.md#fundamental-types)).
+  - `m_o` is the outcome that the oracle commits to publish. 
+
+`e`: a 32-byte sha256 outcome representing a challenge calculated as `e = H(R|R'|R_2|R_2')` (see [here](https://note.com/crypto_garage/n/na1ef06177b27)).  
+
+`s`: a 32-byte signature verification scalar calculated as `s = r_2 + re` (see [here](https://note.com/crypto_garage/n/na1ef06177b27)).
+
+#### `dleq_proof`
+1. data: 
+  * [`point`:`R'`]
+  * [`sha256`:`e`]
+  * [`scalar`:`s`]
 
 ### The `funding_signatures` Type
 

--- a/Messaging.md
+++ b/Messaging.md
@@ -339,7 +339,7 @@ This type contains CET signatures and any necessary information linking the sign
 ### The `ecdsa_adaptor_signature` Type
 This type contains an ECDSA adaptor signature, represented as a 65-byte stream as follows:  
 
-`R`: a 33-byte compressed elliptic-curve adaptor point as described in [Fundamental Types](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Messaging.md#fundamental-types).
+`R`: a 33-byte compressed elliptic-curve point as described in [Fundamental Types](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Messaging.md#fundamental-types).
 - The point `R` is calculated by multiplying a random value `k` by the adaptor point `Y`, as described [here](https://github.com/discreetlogcontracts/dlcspecs/blob/master/ECDSA-adaptor.md#encrypted-signing).
 - `Y` is an adaptor point calculated as defined [here](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Introduction.md#signature-point).
 

--- a/Messaging.md
+++ b/Messaging.md
@@ -360,11 +360,16 @@ This type contains an ECDSA adaptor signature, represented as a 65-byte stream a
 This type contains a 97-byte zero-knowledge proof of discrete log equality. The values here presented are built as described in [this article by Ichiro Kuwahara](https://medium.com/crypto-garage/adaptor-signature-in-discreet-log-contracts-on-ecdsa-c8c04197e11f).  
 
 `R'`: a 33-byte compressed elliptic-curve adaptor point as described in [Fundamental Types](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Messaging.md#fundamental-types).  
-- The point `R'` is derived as `R' = rT`, where `T` is the tweak point (or adaptor point) and `r` is the same random value used to calculate `R`.
+- The point `R'` is derived as `R' = r * T`, where `T` is the tweak point (or adaptor point) and `r` is the same random value used to calculate `R`.
 
-`e`: a 32-byte sha256 outcome representing a challenge calculated as `e = H(R|R'|R_2|R_2')` (see [here](https://note.com/crypto_garage/n/na1ef06177b27)). Also, the hash function needs to use a tag as specified [here](https://github.com/discreetlogcontracts/dlcspecs/blob/master/ECDSA-adaptor.md#proof-of-discrete-logarithm-equality).
+`e`: a 32-byte sha256 outcome representing a challenge calculated as `e = H(R|R'|R_2|R_2')` (see [here](https://note.com/crypto_garage/n/na1ef06177b27)). Also, the hash function needs to use a tag as specified [here](https://github.com/discreetlogcontracts/dlcspecs/blob/master/ECDSA-adaptor.md#proof-of-discrete-logarithm-equality). The points `R_2` and `R_2'` are defined as follows: 
+  
+  - `R_2 = r_2 * G`
+  - `R_2' = r_2 * T`
 
-`s`: a 32-byte signature verification scalar calculated as `s = r_2 + re` (see [here](https://note.com/crypto_garage/n/na1ef06177b27)).
+`s`: a 32-byte signature verification scalar calculated as `s = r_2 + re` (see [here](https://note.com/crypto_garage/n/na1ef06177b27)), where:  
+
+  - `r_2` is a random value, used to generate `R_2` and `R_2'`.
 
 #### `dleq_proof`
 1. data: 

--- a/Messaging.md
+++ b/Messaging.md
@@ -342,7 +342,7 @@ This type contains an ECDSA adaptor signature, represented as a 65-byte stream a
 `R`: a 33-byte compressed elliptic-curve adaptor point as described in [Fundamental Types](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Messaging.md#fundamental-types).
 - The point `R` is calculated by multiplying a random value `r` by `G`, as described [here](https://note.com/crypto_garage/n/na1ef06177b27).
 
-`s'`: a 32-byte encrypted signature scalar. This is calculated as ```s' = r^-1(H(m) + rTp)``` as explained [here](https://note.com/crypto_garage/n/na1ef06177b27).  
+`s'`: a 32-byte encrypted signature scalar. This is calculated as `s' = r^-1 * (H(m) + r * T * p)` as explained [here](https://note.com/crypto_garage/n/na1ef06177b27).  
 - `r` is the same random value used for `R`.
 - `T` is a tweak point (or adaptor point) and is calculated as `T = R_o + H(R_o|P_o|m_o)`, where:
   - `R_o` is the nonce point published by the oracle, encoded as `x_point` (see  [Fundamental Types](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Messaging.md#fundamental-types)).

--- a/Messaging.md
+++ b/Messaging.md
@@ -500,6 +500,8 @@ Nadav Kohen <nadavk25@gmail.com>
 
 Ben Carman <benthecarman@live.com>
 
+Raúl Cano <raul.cano.argamasilla@gmail.com>
+
 ![Creative Commons License](https://i.creativecommons.org/l/by/4.0/88x31.png "License CC-BY")
 <br>
 This work is licensed under a [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/).

--- a/Messaging.md
+++ b/Messaging.md
@@ -337,14 +337,19 @@ This type contains CET signatures and any necessary information linking the sign
    * [`dleq_proof`:`dleq_prf_n`]
 
 ### The `ecdsa_adaptor_signature` Type
-This type contains an ECDSA adaptor signature, represented as a 65-byte stream that contains the following:  
+This type contains an ECDSA adaptor signature, represented as a 65-byte stream as follows:  
 
 `R`: a 33-byte compressed elliptic-curve adaptor point as described in [Fundamental Types](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Messaging.md#fundamental-types).
-- The point `R` is calculated by multiplying the random value `r` by `G`, as described [here](https://note.com/crypto_garage/n/na1ef06177b27).
+- The point `R` is calculated by multiplying a random value `r` by `G`, as described [here](https://note.com/crypto_garage/n/na1ef06177b27).
 
 `s'`: a 32-byte encrypted signature scalar. This is calculated as ```s' = r^-1(H(m) + rTp)``` as explained [here](https://note.com/crypto_garage/n/na1ef06177b27).  
-- Note that `H(m)` is the 32-byte transaction id `txid` (not to confuse with the `m_o` in the Tweak points, where `m_o` is the outcome value published by the oracle, such as `heads` or `tails`, etc.)
-- To calculate the adaptor signature scalar for numeric decomposition, one needs to calculate one tweak point `T_i` per digit and then obtain `T = T_0 + T_1 + ... + T_(i-1)` as described [here](https://medium.com/crypto-garage/optimizing-numeric-outcome-dlc-creation-6d6091ac0e47).
+- `r` is the same random value used for `R`.
+- `T` is a tweak point (or adaptor point) and is calculated as `T = R_o + H(R_o|P_o|m_o)`, where:
+  - `R_o` is the nonce point published by the oracle, encoded as `x_point` (see  [Fundamental Types](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Messaging.md#fundamental-types)).
+  - `P_o` is the oracle public key, encoded as `x_point` (see  [Fundamental Types](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Messaging.md#fundamental-types)).
+  - `m_o` is the outcome that the oracle commits to publish. 
+- `H(m)` is the 32-byte transaction id `txid` (not to confuse with the `m_o` in the Tweak points, where `m_o` is the outcome value published by the oracle, such as `heads` or `tails`, etc.)
+- In numeric decomposition, one needs to calculate one tweak point `T_i` per digit and then obtain `T = T_0 + T_1 + ... + T_(i-1)` as described [here](https://medium.com/crypto-garage/optimizing-numeric-outcome-dlc-creation-6d6091ac0e47).
 
 #### `ecdsa_adaptor_signature`
 1. data: 
@@ -355,13 +360,9 @@ This type contains an ECDSA adaptor signature, represented as a 65-byte stream t
 This type contains a 97-byte zero-knowledge proof of discrete log equality. The values here presented are built as described in [this article by Ichiro Kuwahara](https://medium.com/crypto-garage/adaptor-signature-in-discreet-log-contracts-on-ecdsa-c8c04197e11f).  
 
 `R'`: a 33-byte compressed elliptic-curve adaptor point as described in [Fundamental Types](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Messaging.md#fundamental-types).  
-- The point `R'` is derived as `R' = rT`, where `T` is the tweak point (or adaptor point).
-- The tweak point `T` is calculated as `T = R_o + H(R_o|P_o|m_o)`, where:
-  - `R_o` is the nonce point published by the oracle, encoded as `x_point` (see  [Fundamental Types](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Messaging.md#fundamental-types)).
-  - `P_o` is the oracle public key, encoded as `x_point` (see  [Fundamental Types](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Messaging.md#fundamental-types)).
-  - `m_o` is the outcome that the oracle commits to publish. 
+- The point `R'` is derived as `R' = rT`, where `T` is the tweak point (or adaptor point) and `r` is the same random value used to calculate `R`.
 
-`e`: a 32-byte sha256 outcome representing a challenge calculated as `e = H(R|R'|R_2|R_2')` (see [here](https://note.com/crypto_garage/n/na1ef06177b27)).  
+`e`: a 32-byte sha256 outcome representing a challenge calculated as `e = H(R|R'|R_2|R_2')` (see [here](https://note.com/crypto_garage/n/na1ef06177b27)). Also, the hash function needs to use a tag as specified [here](https://github.com/discreetlogcontracts/dlcspecs/blob/master/ECDSA-adaptor.md#proof-of-discrete-logarithm-equality).
 
 `s`: a 32-byte signature verification scalar calculated as `s = r_2 + re` (see [here](https://note.com/crypto_garage/n/na1ef06177b27)).
 

--- a/Messaging.md
+++ b/Messaging.md
@@ -344,7 +344,7 @@ This type contains an ECDSA adaptor signature, represented as a 65-byte stream a
 
 `s'`: a 32-byte encrypted signature scalar. This is calculated as `s' = r^-1 * (H(m) + r * T * p)` as explained [here](https://note.com/crypto_garage/n/na1ef06177b27).  
 - `r` is the same random value used for `R`.
-- `T` is a tweak point (or adaptor point) and is calculated as `T = R_o + H(R_o|P_o|m_o)`, where:
+- `T` is a tweak point (or adaptor point) and is calculated as `T = R_o + H(P_o|R_o|m_o)`, where:
   - `R_o` is the nonce point published by the oracle, encoded as `x_point` (see  [Fundamental Types](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Messaging.md#fundamental-types)).
   - `P_o` is the oracle public key, encoded as `x_point` (see  [Fundamental Types](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Messaging.md#fundamental-types)).
   - `m_o` is the outcome that the oracle commits to publish. 

--- a/Messaging.md
+++ b/Messaging.md
@@ -340,42 +340,44 @@ This type contains CET signatures and any necessary information linking the sign
 This type contains an ECDSA adaptor signature, represented as a 65-byte stream as follows:  
 
 `R`: a 33-byte compressed elliptic-curve adaptor point as described in [Fundamental Types](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Messaging.md#fundamental-types).
-- The point `R` is calculated by multiplying a random value `r` by `G`, as described [here](https://note.com/crypto_garage/n/na1ef06177b27).
+- The point `R` is calculated by multiplying a random value `k` by the adaptor point `Y`, as described [here](https://github.com/discreetlogcontracts/dlcspecs/blob/master/ECDSA-adaptor.md#encrypted-signing).
+- `Y` is an adaptor point calculated as defined [here](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Introduction.md#signature-point).
 
-`s'`: a 32-byte encrypted signature scalar. This is calculated as `s' = r^-1 * (H(m) + r * T * p)` as explained [here](https://note.com/crypto_garage/n/na1ef06177b27).  
-- `r` is the same random value used for `R`.
-- `T` is a tweak point (or adaptor point) and is calculated as `T = R_o + H(P_o|R_o|m_o)`, where:
-  - `R_o` is the nonce point published by the oracle, encoded as `x_point` (see  [Fundamental Types](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Messaging.md#fundamental-types)).
-  - `P_o` is the oracle public key, encoded as `x_point` (see  [Fundamental Types](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Messaging.md#fundamental-types)).
-  - `m_o` is the outcome that the oracle commits to publish. 
-- `H(m)` is the 32-byte transaction id `txid` (not to confuse with the `m_o` in the Tweak points, where `m_o` is the outcome value published by the oracle, such as `heads` or `tails`, etc.)
-- In numeric decomposition, one needs to calculate one tweak point `T_i` per digit and then obtain `T = T_0 + T_1 + ... + T_(i-1)` as described [here](https://medium.com/crypto-garage/optimizing-numeric-outcome-dlc-creation-6d6091ac0e47).
+`s_a`: a 32-byte encrypted signature scalar. This is calculated as `s_a = k⁻¹ (m + r * x)` as explained [here](https://github.com/discreetlogcontracts/dlcspecs/blob/master/ECDSA-adaptor.md#encrypted-signing).  
+- `k` is the same random value used to obtain `R`.
+- `m` is the 32-byte transaction digest.
+- `x` is the signer's private key.
+
 
 #### `ecdsa_adaptor_signature`
 1. data: 
   * [`point`:`R`]
-  * [`scalar`:`s'`]
+  * [`scalar`:`s_a`]
 
 ### The `dleq_proof` Type
-This type contains a 97-byte zero-knowledge proof of discrete log equality. The values here presented are built as described in [this article by Ichiro Kuwahara](https://medium.com/crypto-garage/adaptor-signature-in-discreet-log-contracts-on-ecdsa-c8c04197e11f).  
+This type contains a 97-byte zero-knowledge proof of discrete log equality.
 
-`R'`: a 33-byte compressed elliptic-curve adaptor point as described in [Fundamental Types](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Messaging.md#fundamental-types).  
-- The point `R'` is derived as `R' = r * T`, where `T` is the tweak point (or adaptor point) and `r` is the same random value used to calculate `R`.
+`R_a`: a 33-byte compressed elliptic-curve adaptor point as described in [Fundamental Types](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Messaging.md#fundamental-types).  
+- The point `R_a` is derived as `R_a = k * G`, where `G` is the generator point in the curve, and `k` is the same random value used to calculate `R` in the `ecdsa_adaptor_signature` type.
 
-`e`: a 32-byte sha256 outcome representing a challenge calculated as `e = H(R|R'|R_2|R_2')` (see [here](https://note.com/crypto_garage/n/na1ef06177b27)). Also, the hash function needs to use a tag as specified [here](https://github.com/discreetlogcontracts/dlcspecs/blob/master/ECDSA-adaptor.md#proof-of-discrete-logarithm-equality). The points `R_2` and `R_2'` are defined as follows: 
+`b`: a 32-byte sha256 outcome representing a challenge calculated as `b = H(R_a || Y || R || A_G || A_Y)` (see [here](https://github.com/discreetlogcontracts/dlcspecs/blob/master/ECDSA-adaptor.md#proving)). Note that the hash function needs to use a tag as specified [here](https://github.com/discreetlogcontracts/dlcspecs/blob/master/ECDSA-adaptor.md#proof-of-discrete-logarithm-equality). The points `A_G` and `A_Y` are defined as follows: 
   
-  - `R_2 = r_2 * G`
-  - `R_2' = r_2 * T`
+  - `A_G = a * G`
+  - `A_Y = a * Y`
+  - `a` is a random value (see [here](https://github.com/discreetlogcontracts/dlcspecs/blob/master/ECDSA-adaptor.md#proving)).
+  - `R`, `Y` are the same values used in the `ecdsa_adaptor_signature` related to this proof.
 
-`s`: a 32-byte signature verification scalar calculated as `s = r_2 + re` (see [here](https://note.com/crypto_garage/n/na1ef06177b27)), where:  
+`c`: a 32-byte signature verification scalar calculated as `c = a + b * k` (see [here](https://github.com/discreetlogcontracts/dlcspecs/blob/master/ECDSA-adaptor.md#proving)), where:  
 
-  - `r_2` is a random value, used to generate `R_2` and `R_2'`.
+  - `a` is the random value described above.
+  - `b` is the challenge as described above.
+  - `k` is the secret random number used for calculating points `R` and `R_a`
 
 #### `dleq_proof`
 1. data: 
-  * [`point`:`R'`]
-  * [`sha256`:`e`]
-  * [`scalar`:`s`]
+  * [`point`:`R_a`]
+  * [`sha256`:`b`]
+  * [`scalar`:`c`]
 
 ### The `funding_signatures` Type
 

--- a/Messaging.md
+++ b/Messaging.md
@@ -346,6 +346,7 @@ This type contains an ECDSA adaptor signature, represented as a 65-byte stream a
 `s_a`: a 32-byte encrypted signature scalar. This is calculated as `s_a = k⁻¹ (m + r * x)` as explained [here](https://github.com/discreetlogcontracts/dlcspecs/blob/master/ECDSA-adaptor.md#encrypted-signing).  
 - `k` is the same random value used to obtain `R`.
 - `m` is the 32-byte transaction digest.
+- `r`  is the x-coordinate of `R` (mod `n`)
 - `x` is the signer's private key.
 
 


### PR DESCRIPTION
Following the discussion I initiated here https://github.com/discreetlogcontracts/dlcspecs/issues/214
I believe it will be positive to add a detailed description to what exactly are the types `ecdsa_adaptor_signature` and `dleq_proof`. For this, I also add a new convenience type `scalar`. 