### PR TITLE
Order of hash function parameters in adaptor point

### DIFF
--- a/NumericOutcomeCompression.md
+++ b/NumericOutcomeCompression.md
@@ -44,7 +44,7 @@ where attestations are ignored.
 ## Adaptor Points with Multiple Attestations
 
 Given public key `P` and nonces `R1, ..., Rn` we can compute `n` individual adaptor points for
-a given event `(d1, ..., dn)` in the usual way: `si * G = Ri + H(P, Ri, di)*P`.
+a given event `(d1, ..., dn)` in the usual way: `si * G = Ri + H(Ri, P, di)*P`.
 To compute an aggregate adaptor point for all events which agree on the first `m` digits, where
 `m` is any positive number less than or equal to `n`, the sum of the corresponding adaptor points
 points is used: `s(1..m) * G = (s1 + s2 + ... + sm) * G = s1 * G + s2 * G + ... + sm * G`.


### PR DESCRIPTION
I discovered a very minor inconsistency in specs regarding the hash function in the adaptor points (aka tweak points or signature points).
- In the [introduction](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Introduction.md#signature-point) is described as `S = R + H(R || P || m) * P ` (R before the P)
- In the [numeric outcome](https://github.com/discreetlogcontracts/dlcspecs/blob/master/NumericOutcomeCompression.md#adaptor-points-with-multiple-attestations) section is described as `si * G = Ri + H(P, Ri, di)*P` (P before the Ri)
- In other sources (i.e. [CryptoGarage](https://note.com/crypto_garage/n/na1ef06177b27)), it's described as `T = R + H(R || P || m)*P`  (R before the P)

Hence, for clarity and consistency, this pull request proposes to change the `H(P, Ri, di)` to `H(Ri, P, di)`.

In all fairness, the notation `H(P, Ri, di)` does not imply that the byte chain will be built in the same order the parameters are present in the function call (the operator `||` implies concatenation, the comma `,` does not). However, for clarity, I believe we should make sure to use the same order and avoid potential confusion.