### PR TITLE
Signatures in oracle messages updated to Schnorr type (ECDSA signatures specified currently)

### DIFF
--- a/Messaging.md
+++ b/Messaging.md
@@ -124,6 +124,7 @@ The following convenience types are also defined:
 * `contract_id`: a 32-byte contract_id (see [Protocol Specification](Protocol.md))
 * `sha256`: a 32-byte SHA2-256 hash
 * `signature`: a 64-byte bitcoin Elliptic Curve signature
+* `schnorr_signature`: a 64-byte Schnorr signature
 * `ecdsa_adaptor_signature`: a 65-byte ECDSA adaptor signature (TODO: link to doc once [#50](https://github.com/discreetlogcontracts/dlcspecs/issues/50) is done)
 * `dleq_proof`: a 97-byte zero-knowledge proof of discrete log equality (TODO: link to doc once [#50](https://github.com/discreetlogcontracts/dlcspecs/issues/50) is done)
 * `x_point`: a 32-byte x-only public key with implicit y-coordinate being even as in [BIP 340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#design)
@@ -419,11 +420,11 @@ See [the Oracle specifications](./Oracle.md#oracle-announcements) for more detai
 
 1. type: 55332
 1. data:
-   * [`signature`:`annoucement_signature`]
+   * [`schnorr_signature`:`annoucement_signature`]
    * [`x_point`:`oracle_public_key`]
    * [`oracle_event`:`oracle_event`]
 
-where `signature` is a Schnorr signature over a sha256 hash of the serialized `oracle_event`, using the tag `announcement/v0`.
+where `schnorr_signature` is a Schnorr signature over a sha256 hash of the serialized `oracle_event`, using the tag `announcement/v0`.
 
 ### The `oracle_attestation` Type
 
@@ -440,9 +441,9 @@ See [the Oracle specifications](./Oracle.md#oracle-attestations) for more detail
     * [`string`:`event_id`]
     * [`x_point`:`oracle_public_key`]
     * [`u16`: `nb_signatures`]
-    * [`signature`:`signature_1`]
+    * [`schnorr_signature`:`signature_1`]
     * ...
-    * [`signature`:`signature_n`]
+    * [`schnorr_signature`:`signature_n`]
     * [`string`:`outcome_1`]
     * ...
     * [`string`:`outcome_n`]


### PR DESCRIPTION
The signatures included in  `oracle_announcement` and `oracle_attestation` should be specified as Schnorr. However, the way it is described now, it uses the field type `signature`, which is defined as an ECDSA signature.
This PR creates a new convenience type `schnorr_signature` and uses it in the descriptions of the `oracle_announcement` and `oracle_attestation`.

Current definition of the `signature` convenience type:
https://github.com/discreetlogcontracts/dlcspecs/blob/9cd9148938c616690c79d99ec6f330e213c246c5/Messaging.md?plain=1#L126

According to the current spec, the signature within the announcement is a Schnorr signature, but the ECDSA `signature` field is used. See here an explicit contradition:
https://github.com/discreetlogcontracts/dlcspecs/blob/9cd9148938c616690c79d99ec6f330e213c246c5/Messaging.md?plain=1#L418-L427

The oracle attestation also needs of Schnorr signatures, but is pointing to the `signature` type.
https://github.com/discreetlogcontracts/dlcspecs/blob/9cd9148938c616690c79d99ec6f330e213c246c5/Messaging.md?plain=1#L436-L452

For reference, this implementation of the oracle announcement and attestation uses Schnorr signatures:
https://docs.rs/dlc-messages/latest/dlc_messages/oracle_msgs/struct.OracleAnnouncement.html
https://docs.rs/dlc-messages/latest/dlc_messages/oracle_msgs/struct.OracleAttestation.html
